### PR TITLE
Falsches Gleis in Abfahrtenliste korrigieren

### DIFF
--- a/MunichCommuter/DepartureDetailView.swift
+++ b/MunichCommuter/DepartureDetailView.swift
@@ -805,8 +805,12 @@ struct DepartureDetailView: View {
         var platforms = Set<String>()
         
         for departure in mvvService.departures {
-            // Add platform info if available
-            if let platform = departure.location?.properties?.platform {
+            // Add platform info if available, using the same priority as display and filtering
+            let platform = departure.location?.properties?.platformName 
+                         ?? departure.location?.properties?.plannedPlatformName 
+                         ?? departure.location?.properties?.platform
+            
+            if let platform = platform {
                 platforms.insert(platform)
             }
         }
@@ -913,7 +917,15 @@ struct DepartureRowView: View {
                     .frame(maxWidth: .infinity, alignment: .leading) // Explicit maxWidth
                 
                 HStack(spacing: 8) {
-                    if let platform = departure.location?.properties?.platform {
+                    if let platformName = departure.location?.properties?.platformName {
+                        Text("Gleis \(platformName)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    } else if let plannedPlatformName = departure.location?.properties?.plannedPlatformName {
+                        Text("Gleis \(plannedPlatformName)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    } else if let platform = departure.location?.properties?.platform {
                         Text("Gleis \(platform)")
                             .font(.caption)
                             .foregroundColor(.secondary)

--- a/MunichCommuter/FilteringHelper.swift
+++ b/MunichCommuter/FilteringHelper.swift
@@ -32,7 +32,12 @@ class FilteringHelper {
     // MARK: - Platform Filtering
     static func hasPlatformMatch(departure: StopEvent, platforms: [String]) -> Bool {
         // Check if any of the platform filters match this departure
-        guard let departurePlatform = departure.location?.properties?.platform else {
+        // Try platformName first, then plannedPlatformName, then fall back to platform
+        let departurePlatform = departure.location?.properties?.platformName 
+                             ?? departure.location?.properties?.plannedPlatformName 
+                             ?? departure.location?.properties?.platform
+        
+        guard let departurePlatform = departurePlatform else {
             return false // No platform info available
         }
         


### PR DESCRIPTION
Prioritize `platformName` and `plannedPlatformName` for platform display and filtering to show correct user-friendly platform numbers.

The API provides multiple platform fields. Previously, the app used `platform`, which sometimes contained an internal ID (e.g., "83"). This change ensures the user-friendly `platformName` or `plannedPlatformName` is used first, falling back to `platform` if others are unavailable, resolving cases where an incorrect platform number was displayed in the departure list and used for filtering.

---

[Open in Web](https://cursor.com/agents?id=bc-b816a468-49a6-4b36-8341-ef1d4b293350) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b816a468-49a6-4b36-8341-ef1d4b293350) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)